### PR TITLE
Fix failing installation.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M8")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")


### PR DESCRIPTION
Was receiving `com.typesafe.sbt#sbt-native-packager;1.2.0-M8: not found`.
Checked: http://dl.bintray.com/sbt/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/
Only 2 versions exist, the later of the two being `1.2.2`.
Updated to reflect this.